### PR TITLE
[UPT] Bump aiohttp 3.8.4 → 3.13.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 chardet==3.0.4
-aiohttp==3.8.4
+aiohttp==3.13.3
 beautifulsoup4==4.12.3
 httpx[http2]
 Flask==3.0.0


### PR DESCRIPTION
Bumps aiohttp from 3.8.4 to 3.13.3.

**Change:** Single line in `requirements.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)