### PR TITLE
[UPT] Bump beautifulsoup4 4.12.3 → 4.14.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 chardet==3.0.4
 aiohttp==3.8.4
-beautifulsoup4==4.12.3
+beautifulsoup4==4.14.3
 httpx[http2]
 Flask==3.0.0
 celery==5.2.7


### PR DESCRIPTION
Bumps beautifulsoup4 from 4.12.3 to 4.14.3.

**Change:** Single line in `requirements.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)