### PR TITLE
[UPT] Bump Flask 3.0.0 → 3.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ chardet==3.0.4
 aiohttp==3.8.4
 beautifulsoup4==4.12.3
 httpx[http2]
-Flask==3.0.0
+Flask==3.1.3
 celery==5.2.7
 Flask-Cors==4.0.0
 requests==2.27.0


### PR DESCRIPTION
Bumps Flask from 3.0.0 to 3.1.3.

**Change:** Single line in `requirements.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)