### PR TITLE
[UPT] Bump Flask-Cors 4.0.0 → 6.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ beautifulsoup4==4.12.3
 httpx[http2]
 Flask==3.0.0
 celery==5.2.7
-Flask-Cors==4.0.0
+Flask-Cors==6.0.2
 requests==2.27.0
 bs4==0.0.1
 cfscrape==2.1.1


### PR DESCRIPTION
Bumps Flask-Cors from 4.0.0 to 6.0.2.

**Change:** Single line in `requirements.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)