### PR TITLE
[UPT] Bump instaloader 4.12 → 4.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ tweety-ns @ https://github.com/mahrtayyab/tweety/archive/main.zip
 geopy==1.22.0
 git+https://github.com/KennBro/yagooglesearch.git@origin/add-output-param#egg=yagooglesearch
 socialscan==2.0.0
-instaloader==4.12
+instaloader==4.15
 requests-futures==1.0.0
 torrequest
 holehe==1.61


### PR DESCRIPTION
Bumps instaloader from 4.12 to 4.15.

**Change:** Single line in `requirements.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)