### PR TITLE
[UPT] Bump tweepy 4.5.0 → 4.16.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-Cors==4.0.0
 requests==2.27.0
 bs4==0.0.1
 cfscrape==2.1.1
-tweepy==4.5.0
+tweepy==4.16.0
 tweety-ns @ https://github.com/mahrtayyab/tweety/archive/main.zip
 geopy==1.22.0
 git+https://github.com/KennBro/yagooglesearch.git@origin/add-output-param#egg=yagooglesearch


### PR DESCRIPTION
Bumps tweepy from 4.5.0 to 4.16.0.

**Change:** Single line in `requirements.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)