### PR TITLE
[UPT] Bump spotipy 2.16.1 → 2.25.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ TranslatorX==1.2
 vaderSentiment==3.3.2
 emailrep==0.0.4
 stop_words
-spotipy==2.16.1
+spotipy==2.25.2
 twitch-python
 parse
 browser-cookie3


### PR DESCRIPTION
Bumps spotipy from 2.16.1 to 2.25.2.

**Change:** Single line in `requirements.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)