### PR TITLE
[UPT] Bump browser-cookie3 → 0.20.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ stop_words
 spotipy==2.16.1
 twitch-python
 parse
-browser-cookie3
+browser-cookie3==0.20.1
 google-api-python-client==2.33.0
 python-Levenshtein
 requests_html


### PR DESCRIPTION
Pins browser-cookie3 to 0.20.1 (was unpinned).

**Change:** Single line in `requirements.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)