### PR TITLE
[UPT] Bump google-api-python-client 2.33.0 → 2.190.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ spotipy==2.16.1
 twitch-python
 parse
 browser-cookie3
-google-api-python-client==2.33.0
+google-api-python-client==2.190.0
 python-Levenshtein
 requests_html
 fontawesome==5.10.1.post1


### PR DESCRIPTION
Bumps google-api-python-client from 2.33.0 to 2.190.0.

**Change:** Single line in `requirements.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)