### PR TITLE
[UPT] Bump redis 3.5.3 → 7.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ holehe==1.61
 search-engine-parser==0.6.8
 # git+https://github.com/KennBro/search-engine-parser.git@origin/KALI/2022.2#egg=search-engine-parser
 fuzzywuzzy==0.18.0
-redis==3.5.3
+redis==7.2.0
 langdetect==1.0.8
 # googletrans==3.0.0
 TranslatorX==1.2


### PR DESCRIPTION
Bumps redis from 3.5.3 to 7.2.0.

**Change:** Single line in `requirements.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)