### PR TITLE
[UPT] Bump TikTokApi 6.3.0 → 7.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,4 +37,4 @@ requests_html
 fontawesome==5.10.1.post1
 peopledatalabs==3.1.3
 playwright==1.30.0
-TikTokApi==6.3.0
+TikTokApi==7.3.1


### PR DESCRIPTION
Bumps TikTokApi from 6.3.0 to 7.3.1.

**Change:** Single line in `requirements.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)