### PR TITLE
fix: correct 'occoured' to 'occurred' typo in Skype error message

### DIFF
--- a/backend/modules/skype/skype_tasks.py
+++ b/backend/modules/skype/skype_tasks.py
@@ -35,7 +35,7 @@ def t_skype(email, from_m="Initial"):
 
         results = str(soup.div).replace("</div>", "").split("<br/>")[1:]
 
-        if results != ["An error occoured!"] and results != [
+        if results != ["An error occurred!"] and results != [
             "There were no Skype usernames found with this email."
         ]:
             raw_node = []


### PR DESCRIPTION
## Summary
Fixes user-facing error message typo in `backend/modules/skype/skype_tasks.py` line 38.

## Change
```
- if results != ["An error occoured!"] ...
+ if results != ["An error occurred!"] ...
```

## Checklist
- [x] Single commit (surgical fix)
- [x] No unrelated changes
